### PR TITLE
feat(system): Dropdown 컴포넌트 구현

### DIFF
--- a/src/app/(sidebar)/(my-info)/page.tsx
+++ b/src/app/(sidebar)/(my-info)/page.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { Icon } from '@/system/components';
 import { InfoCardList } from './components/InfoCardList';
 

--- a/src/system/components/Dropdown/Dropdown.tsx
+++ b/src/system/components/Dropdown/Dropdown.tsx
@@ -1,0 +1,14 @@
+import { CheckboxItem } from './compounds/CheckboxItem';
+import { Content } from './compounds/Content';
+import { Root } from './compounds/Root';
+import { Separator } from './compounds/Separator';
+import { Trigger } from './compounds/Trigger';
+import { TriggerArrow } from './compounds/TriggerArrow';
+
+export const Dropdown = Object.assign(Root, {
+  Trigger,
+  TriggerArrow,
+  Content,
+  Separator,
+  CheckboxItem,
+});

--- a/src/system/components/Dropdown/Dropdown.tsx
+++ b/src/system/components/Dropdown/Dropdown.tsx
@@ -1,4 +1,4 @@
-import { CheckboxItem } from './compounds/CheckboxItem';
+import { CheckedItem } from './compounds/CheckedItem';
 import { Content } from './compounds/Content';
 import { Root } from './compounds/Root';
 import { Separator } from './compounds/Separator';
@@ -10,5 +10,5 @@ export const Dropdown = Object.assign(Root, {
   TriggerArrow,
   Content,
   Separator,
-  CheckboxItem,
+  CheckedItem,
 });

--- a/src/system/components/Dropdown/anatomy.ts
+++ b/src/system/components/Dropdown/anatomy.ts
@@ -1,0 +1,1 @@
+export type DropdownAnatomy = 'trigger-arrow' | 'content' | 'separator' | 'checkbox-item';

--- a/src/system/components/Dropdown/compounds/CheckboxItem.tsx
+++ b/src/system/components/Dropdown/compounds/CheckboxItem.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { If } from '@/system/utils/If';
+import { Icon } from '../..';
+import { ComponentProps, forwardRef } from 'react';
+import { mergeProps } from '@/utils/mergeProps';
+import { color } from '@/system/token/color';
+import { useDropdownContext } from '../context';
+
+interface Props extends ComponentProps<'button'> {
+  checked?: boolean;
+}
+
+export const CheckboxItem = forwardRef<HTMLButtonElement, Props>(function CheckboxItem(
+  { checked, disabled, children, ...restProps },
+  ref,
+) {
+  const { styles, logics } = useDropdownContext();
+
+  return (
+    <button ref={ref} disabled={disabled} {...mergeProps(styles['checkbox-item'], logics['checkbox-item'], restProps)}>
+      {children}
+      <If condition={checked}>
+        <Icon name="check" color={color.neutral30} size={20} />
+      </If>
+    </button>
+  );
+});

--- a/src/system/components/Dropdown/compounds/CheckedItem.tsx
+++ b/src/system/components/Dropdown/compounds/CheckedItem.tsx
@@ -11,7 +11,7 @@ interface Props extends ComponentProps<'button'> {
   checked?: boolean;
 }
 
-export const CheckboxItem = forwardRef<HTMLButtonElement, Props>(function CheckboxItem(
+export const CheckedItem = forwardRef<HTMLButtonElement, Props>(function CheckedItem(
   { checked, disabled, children, ...restProps },
   ref,
 ) {

--- a/src/system/components/Dropdown/compounds/Content.tsx
+++ b/src/system/components/Dropdown/compounds/Content.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import * as RadixDropdownMenu from '@radix-ui/react-dropdown-menu';
+import { ComponentProps } from 'react';
+import { mergeProps } from '@/utils/mergeProps';
+import { useDropdownContext } from '../context';
+
+type ContentProps = ComponentProps<typeof RadixDropdownMenu.Content>;
+
+export function Content(props: ContentProps) {
+  const { styles } = useDropdownContext();
+
+  return <RadixDropdownMenu.Content {...mergeProps(props, styles.content)} />;
+}

--- a/src/system/components/Dropdown/compounds/Root.tsx
+++ b/src/system/components/Dropdown/compounds/Root.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import * as RadixDropdownMenu from '@radix-ui/react-dropdown-menu';
+import { PropsWithChildren, useState } from 'react';
+import { DropdownProvider } from '../context';
+import { useDropdownStyles } from '../styles/useDropdownStyles';
+import { useDropdownLogics } from '../logics/useDropdownLogics';
+
+interface RootProps {
+  defaultOpen?: boolean;
+}
+
+// 추후 Controlled방식도 지원
+export function Root({ defaultOpen = false, children }: PropsWithChildren<RootProps>) {
+  const [open, setOpen] = useState(defaultOpen);
+  const dropdownStyles = useDropdownStyles();
+  const dropdownLogics = useDropdownLogics({ onOpenChange: setOpen });
+
+  return (
+    <RadixDropdownMenu.Root open={open} onOpenChange={setOpen}>
+      <DropdownProvider open={open} styles={dropdownStyles} logics={dropdownLogics} onOpenChange={setOpen}>
+        {children}
+      </DropdownProvider>
+    </RadixDropdownMenu.Root>
+  );
+}

--- a/src/system/components/Dropdown/compounds/Separator.tsx
+++ b/src/system/components/Dropdown/compounds/Separator.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+import { useDropdownContext } from '../context';
+
+export function Separator() {
+  const { styles } = useDropdownContext();
+
+  return <div {...styles.separator} />;
+}

--- a/src/system/components/Dropdown/compounds/Trigger.tsx
+++ b/src/system/components/Dropdown/compounds/Trigger.tsx
@@ -1,0 +1,10 @@
+'use client';
+
+import * as RadixDropdownMenu from '@radix-ui/react-dropdown-menu';
+import { ComponentProps } from 'react';
+
+export type TriggerProps = ComponentProps<typeof RadixDropdownMenu.Trigger>;
+
+export function Trigger({ children }: TriggerProps) {
+  return <RadixDropdownMenu.Trigger>{children}</RadixDropdownMenu.Trigger>;
+}

--- a/src/system/components/Dropdown/compounds/TriggerArrow.tsx
+++ b/src/system/components/Dropdown/compounds/TriggerArrow.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { Icon } from '../..';
+import { useDropdownContext } from '../context';
+import { color } from '@/system/token/color';
+
+export function TriggerArrow() {
+  const { open } = useDropdownContext();
+
+  return (
+    <motion.div
+      variants={{
+        closed: { rotate: '0deg' },
+        opened: { rotate: '-180deg' },
+      }}
+      transition={{ duration: 0.1 }}
+      animate={open ? 'opened' : 'closed'}>
+      <Icon name="downChevron" color={color.neutral30} />
+    </motion.div>
+  );
+}

--- a/src/system/components/Dropdown/context.tsx
+++ b/src/system/components/Dropdown/context.tsx
@@ -1,0 +1,14 @@
+import { generateContext } from '@/lib';
+import { DropdownStyles } from './styles/useDropdownStyles';
+import { DropdownLogics } from './logics/useDropdownLogics';
+
+interface DropdownContext {
+  open: boolean;
+  styles: DropdownStyles;
+  logics: DropdownLogics;
+  onOpenChange: (open: boolean) => void;
+}
+
+export const [DropdownProvider, useDropdownContext] = generateContext<DropdownContext>({
+  name: 'Dropdown',
+});

--- a/src/system/components/Dropdown/logics/useDropdownLogics.ts
+++ b/src/system/components/Dropdown/logics/useDropdownLogics.ts
@@ -1,0 +1,18 @@
+import { DropdownAnatomy } from '../anatomy';
+
+export type DropdownLogics = Record<DropdownAnatomy, any>;
+
+interface Props {
+  onOpenChange: (open: boolean) => void;
+}
+
+export function useDropdownLogics({ onOpenChange }: Props): DropdownLogics {
+  return {
+    content: {},
+    separator: {},
+    'trigger-arrow': {},
+    'checkbox-item': {
+      onClick: () => onOpenChange(false),
+    },
+  };
+}

--- a/src/system/components/Dropdown/styles/useDropdownStyles.ts
+++ b/src/system/components/Dropdown/styles/useDropdownStyles.ts
@@ -1,0 +1,24 @@
+import { DropdownAnatomy } from '../anatomy';
+
+interface DropdownStyle {
+  className?: string;
+}
+
+export type DropdownStyles = Record<DropdownAnatomy, DropdownStyle>;
+
+export function useDropdownStyles(): Record<DropdownAnatomy, DropdownStyle> {
+  return {
+    content: {
+      className:
+        'flex flex-col py-[8px] shadow-[0px_2px_8px_0px_rgba(0,0,0,0.12),0px_0px_1px_0px_rgba(0,0,0,0.08)] min-w-[170px] bg-white rounded-[12px] border-[1px] hover:border-neutral-20',
+    },
+    separator: {
+      className: 'h-[8px] bg-nuetral-3 w-full',
+    },
+    'trigger-arrow': {},
+    'checkbox-item': {
+      className:
+        'flex justify-between items-center mx-[8px] my-[4px] px-[8px] py-[4px] text-label1 font-medium text-neutral-80 rounded-[6px] hover:bg-neutral-3 disabled:text-neutral-30 disabled:bg-white',
+    },
+  };
+}

--- a/src/system/components/index.ts
+++ b/src/system/components/index.ts
@@ -1,5 +1,6 @@
 export { Button } from './Button/Button';
 export type { ButtonProps } from './Button/Button';
+export { Dropdown } from './Dropdown/Dropdown';
 export { Icon } from './Icon/Icon';
 export type { IconProps } from './Icon/Icon';
 export { Text } from './Text/Text';


### PR DESCRIPTION
## 3. 관련 스크린샷을 첨부해주세요.


https://github.com/user-attachments/assets/2975759c-a8d8-40d7-98aa-a08c28bdf5fa

<img width="794" alt="스크린샷 2024-08-21 오전 1 33 12" src="https://github.com/user-attachments/assets/97a37d64-167f-413e-ac16-61062f00edd4">

<br>

## 4. 완료 사항

- Dropdown 컴포넌트 구현

```tsx
<Dropdown>
  <Dropdown.Trigger>
    <Dropdown.TriggerArrow />
  </Dropdown.Trigger>
  <Dropdown.Content>
    <Dropdown.CheckedItem></Dropdown.CheckedItem>
    <Dropdown.CheckedItem></Dropdown.CheckedItem>
    <Dropdown.CheckedItem></Dropdown.CheckedItem>
  </Dropdown.Content>
</Dropdown>
```

<br>

## 5. 추가 사항 / 코드 리뷰 받고 싶은 부분

- 공통적으로 사용되는 곳이 많아 구현합니다.
  - 기존에 shadcn의 UI와 스펙이 우리와 맞지 않는 부분이 많아 필요한 부분만 간단히 재구현합니다.
- Anatomy를 기반으로 styles과 logic레이어를 분리합니다.
  - context를 사용해서 각 컴포넌트에서 style과 logic을 받아 사용합니다.
  - 레이어를 분리함으로써 드롭다운 커스텀의 니즈가 있다면 useDropdownStyles와 useDropdownLogic을 사용하면 원하는 부분만 커스텀하여 구현할 수 있습니다.

<br>
